### PR TITLE
Avoid reading the file with a big buffer, use BufReader.

### DIFF
--- a/src/helpers/path.rs
+++ b/src/helpers/path.rs
@@ -55,11 +55,3 @@ pub fn write_file(filepath: &str, filecontent: &str) -> io::Result<()> {
     file.write_all(filecontent.as_bytes())?;
     Ok(())
 }
-
-pub fn read_file(filepath: &str) -> io::Result<String> {
-    let mut file = File::open(filepath)?;
-    let mut buf: Vec<u8> = Vec::new();
-    file.read_to_end(&mut buf)?;
-    let res = String::from_utf8(buf).unwrap(); // UTF8 error will crash...
-    Ok(res)
-}

--- a/src/models/workspace.rs
+++ b/src/models/workspace.rs
@@ -81,12 +81,14 @@ impl Workspace {
 
     pub fn from_file(filepath: &str) -> RustamanResult<Self> {
         info!("Try loading workspace from file {}", filepath);
-        let cfg = path::read_file(filepath)?;
-        debug!("File {} readed ({} chars.)", filepath, cfg.len());
-        let payload = serde_json::from_str::<Payload>(cfg.as_str()).unwrap(); // crash if the format
+        let file = std::fs::File::open(filepath)?;
+        let reader = std::io::BufReader::new(file);
+        let payload = serde_json::from_reader(reader).expect("Format error");
+        debug!("Payload constructed from File {} readed by serde_json with BufReader", filepath);
+
         let workspace = Workspace {
             payload,
-            filepath: filepath.to_owned(),
+            filepath: filepath.to_string(),
         };
         info!("Workspace loaded from file {}", filepath);
         Ok(workspace)


### PR DESCRIPTION
Use serde_json::from_reader to do the magic.
Downside: Debug message lost the bytes rode.
Upside: Avoid allocating a whole big buffer to dump the file.